### PR TITLE
Export Registry constructor

### DIFF
--- a/src/System/Metrics/Prometheus/Registry.hs
+++ b/src/System/Metrics/Prometheus/Registry.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 
 module System.Metrics.Prometheus.Registry
-       ( Registry
+       ( Registry(..)
        , RegistrySample (..)
        , new
        , registerCounter


### PR DESCRIPTION
What's the point of hiding the `Registry` constructor? How do you suppose to use `execRegistryT` if the user can't deconstruct and introspect the `Registry` itself? Had to fork it, would appreciate it in an upstream. Thanks!