### PR TITLE
[24] Fix thunk leak in Histogram

### DIFF
--- a/src/System/Metrics/Prometheus/Metric/Histogram.hs
+++ b/src/System/Metrics/Prometheus/Metric/Histogram.hs
@@ -17,8 +17,8 @@ import           Control.Monad       (void)
 import           Data.Bool           (bool)
 import           Data.IORef          (IORef, atomicModifyIORef', newIORef,
                                       readIORef)
-import           Data.Map            (Map)
-import qualified Data.Map            as Map
+import           Data.Map.Strict     (Map)
+import qualified Data.Map.Strict     as Map
 
 
 newtype Histogram = Histogram { unHistogram :: IORef HistogramSample }
@@ -30,9 +30,9 @@ type Buckets = Map UpperBound Double
 
 data HistogramSample =
     HistogramSample
-    { histBuckets :: Buckets
-    , histSum     :: Double
-    , histCount   :: Int
+    { histBuckets :: !Buckets
+    , histSum     :: !Double
+    , histCount   :: !Int
     }
 
 

--- a/src/System/Metrics/Prometheus/Metric/Summary.hs
+++ b/src/System/Metrics/Prometheus/Metric/Summary.hs
@@ -1,10 +1,10 @@
 module System.Metrics.Prometheus.Metric.Summary where
 
-import           Data.Map (Map)
+import           Data.Map.Strict (Map)
 
 data SummarySample =
     SummarySample
-    { sumQuantiles :: Map Double Int
-    , sumSum       :: Int
-    , sumCount     :: Int
+    { sumQuantiles :: !(Map Double Int)
+    , sumSum       :: !Int
+    , sumCount     :: !Int
     }


### PR DESCRIPTION
Fixes #24 

* Added strictness annotations to `HistogramSample`
* Switch to `Data.Map.Strict` as well to avoid thunk leaks within the `Map`
* Do the same in `Summary` (unimplemented, but this way we won't make the same mistake again)

You can see the thunks disappear in the second ghci session in this gist: https://gist.github.com/ramirez7/591582438c34f6eac9c0b11ca95d086f