### PR TITLE
Rework the push API and allow TLS.

### DIFF
--- a/prometheus.cabal
+++ b/prometheus.cabal
@@ -87,6 +87,7 @@ library
                , bytestring     >= 0.10 && < 0.11
                , containers     >= 0.5  && < 0.7
                , http-client    >= 0.4  && < 0.6
+               , http-client-tls >= 0.3  && < 0.4
                , http-types     >= 0.8  && < 0.13
                , network-uri    >= 2.5  && < 2.7
                , text           >= 1.2  && < 1.3

--- a/src/System/Metrics/Prometheus/Http/Push.hs
+++ b/src/System/Metrics/Prometheus/Http/Push.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module System.Metrics.Prometheus.Http.Push
-       ( pushHttpTextMetrics
+       ( pushMetrics
+       , parseURI
        )
        where
 
@@ -12,12 +13,14 @@ import           Data.Map                              (foldMapWithKey)
 import           Data.Text                             (Text, unpack)
 import           Network.HTTP.Client                   (Request (..),
                                                         RequestBody (..),
-                                                        defaultManagerSettings,
-                                                        httpNoBody, newManager,
+                                                        getUri,
+                                                        httpNoBody,
+                                                        parseRequest,
                                                         requestBody,
                                                         requestFromURI,
                                                         requestHeaders)
 import           Network.HTTP.Types                    (hContentType, methodPut)
+import           Network.HTTP.Client.TLS               (newTlsManager)
 import           Network.URI                           (URI (..), URIAuth,
                                                         nullURI)
 
@@ -25,28 +28,37 @@ import           System.Metrics.Prometheus.Encode.Text (encodeMetrics)
 import           System.Metrics.Prometheus.MetricId    (Labels (..))
 import           System.Metrics.Prometheus.Registry    (RegistrySample)
 
+-- | Parses a uri such that
+-- @
+--   parseURI "https://example.com"
+--      ===
+--   Just (URI "https:" "//example.com"
+-- @
+parseURI :: String -> Maybe URI
+parseURI = fmap getUri . parseRequest
 
--- | Push text metrics to a pushgateway.
-pushHttpTextMetrics :: URIAuth           -- ^ PushGateway URI name, including port number (ex: myGateway.com:8080)
-                    -> Text              -- ^ Job name
-                    -> Labels            -- ^ Label set to use as a grouping key for metrics
-                    -> Int               -- ^ Microsecond push frequency
-                    -> IO RegistrySample -- ^ Action to get latest metrics
-                    -> IO ()
-pushHttpTextMetrics gatewayName jobName labels frequencyMicros getSample = do
-    manager    <- newManager defaultManagerSettings
-    requestUri <- requestFromURI $ buildUri gatewayName jobName labels
+pushMetrics :: URI               -- ^ PushGateway URI name, including port number (ex: @parseUri https://myGateway.com:8080@)
+            -> Text              -- ^ Job name
+            -> Labels            -- ^ Label set to use as a grouping key for metrics
+            -> Int               -- ^ Microsecond push frequency
+            -> IO RegistrySample -- ^ Action to get latest metrics
+            -> IO ()
+pushMetrics gatewayURI jobName labels frequencyMicros getSample = do
+    manager    <- newTlsManager
+    gn         <- maybe (error "Invalid URI Authority") pure gatewayName
+    requestUri <- requestFromURI $ buildUri scheme gn jobName labels
     forever $ getSample >>= flip httpNoBody manager . request requestUri >> threadDelay frequencyMicros
   where
+    URI scheme gatewayName _ _ _ = gatewayURI
     request req sample = req
         { method         = methodPut
         , requestBody    = RequestBodyLBS . toLazyByteString $ encodeMetrics sample
         , requestHeaders = [(hContentType, "text/plain; version=0.0.4")]
         }
 
-buildUri :: URIAuth -> Text -> Labels -> URI
-buildUri gatewayName jobName (Labels ls) = nullURI
-    { uriScheme    = "http:"
+buildUri :: String -> URIAuth -> Text -> Labels -> URI
+buildUri scheme gatewayName jobName (Labels ls) = nullURI
+    { uriScheme    = scheme
     , uriAuthority = Just gatewayName
     , uriPath      = "/metrics/job/" ++ unpack jobName ++ foldMapWithKey labelPath ls
     }


### PR DESCRIPTION
The push API was hard coded to using HTTP.  Instead, allow the user to
specify the full URI and use the http-client-tls manager to service the
task.

I throw an error in the unlikely case someone passes a URI without a URIAuthority but do not see that as a compelling case.  If you disagree we can certainly use `(MonadIO m, MonadThrow m)` and a custom error type with `Exception` instance.