### PR TITLE
Simplified the serve API funtion names

### DIFF
--- a/Example.hs
+++ b/Example.hs
@@ -3,7 +3,7 @@
 module Example where
 
 import           Control.Monad.IO.Class                         (liftIO)
-import           System.Metrics.Prometheus.Http.Scrape          (serveHttpTextMetricsT)
+import           System.Metrics.Prometheus.Http.Scrape          (serveMetricsT)
 import           System.Metrics.Prometheus.Concurrent.RegistryT
 import           System.Metrics.Prometheus.Metric.Counter       (inc)
 import           System.Metrics.Prometheus.MetricId
@@ -20,4 +20,4 @@ main = runRegistryT $ do
 
     -- [...] pass metric handles to the rest of the app
 
-    serveHttpTextMetricsT 8080 ["metrics"] -- http://localhost:8080/metric server
+    serveMetricsT 8080 ["metrics"] -- http://localhost:8080/metric server

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note: Version 0.* supports Prometheus v1.0 and version 2.* supports Prometheus v
 module Example where
 
 import           Control.Monad.IO.Class                         (liftIO)
-import           System.Metrics.Prometheus.Http.Scrape          (serveHttpTextMetricsT)
+import           System.Metrics.Prometheus.Http.Scrape          (serveMetricsT)
 import           System.Metrics.Prometheus.Concurrent.RegistryT
 import           System.Metrics.Prometheus.Metric.Counter       (inc)
 import           System.Metrics.Prometheus.MetricId
@@ -42,7 +42,7 @@ main = runRegistryT $ do
 
     -- [...] pass metric handles to the rest of the app
 
-    serveHttpTextMetricsT 8080 ["metrics"] -- http://localhost:8080/metric server
+    serveMetricsT 8080 ["metrics"] -- http://localhost:8080/metric server
 ```
 
 ## Advanced Usage

--- a/prometheus.cabal
+++ b/prometheus.cabal
@@ -1,5 +1,5 @@
 name:                prometheus
-version:             2.1.2
+version:             2.2.0
 synopsis:            Prometheus Haskell Client
 homepage:            http://github.com/bitnomial/prometheus
 bug-reports:         http://github.com/bitnomial/prometheus/issues
@@ -7,7 +7,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Luke Hoersten
 maintainer:          luke@bitnomial.com, opensource@bitnomial.com
-copyright:           Bitnomial, Inc. (c) 2016-2018
+copyright:           Bitnomial, Inc. (c) 2016-2019
 category:            Metrics, Monitoring, Web, System
 build-type:          Simple
 cabal-version:       >=1.10
@@ -31,7 +31,7 @@ description:
   > module Example where
   >
   > import           Control.Monad.IO.Class                         (liftIO)
-  > import           System.Metrics.Prometheus.Http.Scrape          (serveHttpTextMetricsT)
+  > import           System.Metrics.Prometheus.Http.Scrape          (serveMetricsT)
   > import           System.Metrics.Prometheus.Concurrent.RegistryT
   > import           System.Metrics.Prometheus.Metric.Counter       (inc)
   > import           System.Metrics.Prometheus.MetricId
@@ -48,7 +48,7 @@ description:
   >
   >     -- [...] pass metric handles to the rest of the app
   >
-  >     serveHttpTextMetricsT 8080 ["metrics"] -- http://localhost:8080/metric server
+  >     serveMetricsT 8080 ["metrics"] -- http://localhost:8080/metric server
   >
   .
   [Advanced Usage]

--- a/src/System/Metrics/Prometheus/Http/Scrape.hs
+++ b/src/System/Metrics/Prometheus/Http/Scrape.hs
@@ -2,8 +2,8 @@
 
 module System.Metrics.Prometheus.Http.Scrape
        ( Path
-       , serveHttpTextMetrics
-       , serveHttpTextMetricsT
+       , serveMetrics
+       , serveMetricsT
        , prometheusApp
        )
        where
@@ -40,12 +40,12 @@ import           System.Metrics.Prometheus.Registry             (RegistrySample)
 type Path = [Text]
 
 
-serveHttpTextMetrics :: MonadIO m => Port -> Path -> IO RegistrySample -> m ()
-serveHttpTextMetrics port path = liftIO . run port . prometheusApp path
+serveMetrics :: MonadIO m => Port -> Path -> IO RegistrySample -> m ()
+serveMetrics port path = liftIO . run port . prometheusApp path
 
 
-serveHttpTextMetricsT :: MonadIO m => Port -> Path -> RegistryT m ()
-serveHttpTextMetricsT port path = liftIO . serveHttpTextMetrics port path =<< sample
+serveMetricsT :: MonadIO m => Port -> Path -> RegistryT m ()
+serveMetricsT port path = liftIO . serveMetrics port path =<< sample
 
 
 prometheusApp :: Path -> IO RegistrySample -> Application


### PR DESCRIPTION
Google Protobuf is no longer supported in Prometheus 2.