### PR TITLE
Allow newer versions of bytestring dependency

### DIFF
--- a/prometheus.cabal
+++ b/prometheus.cabal
@@ -1,5 +1,5 @@
 name:                prometheus
-version:             2.2.2
+version:             2.2.3
 synopsis:            Prometheus Haskell Client
 homepage:            http://github.com/bitnomial/prometheus
 bug-reports:         http://github.com/bitnomial/prometheus/issues
@@ -84,7 +84,7 @@ library
 
   build-depends: base            >= 4.9  && < 5
                , atomic-primops  >= 0.8  && < 0.9
-               , bytestring      >= 0.10 && < 0.11
+               , bytestring      >= 0.10 && < 0.12
                , containers      >= 0.5  && < 0.7
                , http-client     >= 0.4  && < 0.8
                , http-client-tls >= 0.3  && < 0.4


### PR DESCRIPTION
I believe that the next major version of bytestring (0.11.x.x) should be compatible with this library.