### PR TITLE
Added listMetricIds and removeMetric to Registry(T)s

### DIFF
--- a/src/System/Metrics/Prometheus/Concurrent/RegistryT.hs
+++ b/src/System/Metrics/Prometheus/Concurrent/RegistryT.hs
@@ -14,8 +14,10 @@ import           System.Metrics.Prometheus.Metric.Counter      (Counter)
 import           System.Metrics.Prometheus.Metric.Gauge        (Gauge)
 import           System.Metrics.Prometheus.Metric.Histogram    (Histogram)
 import qualified System.Metrics.Prometheus.Metric.Histogram    as Histogram
-import           System.Metrics.Prometheus.MetricId            (Labels, Name)
-import           System.Metrics.Prometheus.Registry            (RegistrySample)
+import           System.Metrics.Prometheus.MetricId            (Labels,
+                                                                MetricId, Name)
+import           System.Metrics.Prometheus.Registry            (RegistrySample,
+                                                                listMetricIds)
 
 
 newtype RegistryT m a =
@@ -37,6 +39,14 @@ registerGauge n l = RegistryT ask >>= liftIO . R.registerGauge n l
 
 registerHistogram :: MonadIO m => Name -> Labels -> [Histogram.UpperBound] -> RegistryT m Histogram
 registerHistogram n l b = RegistryT ask >>= liftIO . R.registerHistogram n l b
+
+
+removeMetric :: MonadIO m => MetricId -> RegistryT m ()
+removeMetric i = RegistryT ask >>= liftIO . R.removeMetric i
+
+
+listMetricIds :: MonadIO m => RegistryT m [MetricId]
+listMetricIds = RegistryT ask >>= liftIO . R.listMetricIds
 
 
 sample :: Monad m => RegistryT m (IO RegistrySample)

--- a/src/System/Metrics/Prometheus/Registry.hs
+++ b/src/System/Metrics/Prometheus/Registry.hs
@@ -7,6 +7,8 @@ module System.Metrics.Prometheus.Registry
        , registerCounter
        , registerGauge
        , registerHistogram
+       , listMetricIds
+       , removeMetric
        , sample
        ) where
 
@@ -65,6 +67,14 @@ registerHistogram name labels buckets registry = do
   where
       mid = MetricId name labels
       collision k _ _ = throw (KeyError k)
+
+
+removeMetric :: MetricId -> Registry -> Registry
+removeMetric i (Registry m) = Registry . Map.delete i $ m
+
+
+listMetricIds :: Registry -> [MetricId]
+listMetricIds = Map.keys . unRegistry
 
 
 sample :: Registry -> IO RegistrySample

--- a/src/System/Metrics/Prometheus/RegistryT.hs
+++ b/src/System/Metrics/Prometheus/RegistryT.hs
@@ -13,7 +13,8 @@ import           System.Metrics.Prometheus.Metric.Counter   (Counter)
 import           System.Metrics.Prometheus.Metric.Gauge     (Gauge)
 import           System.Metrics.Prometheus.Metric.Histogram (Histogram)
 import qualified System.Metrics.Prometheus.Metric.Histogram as Histogram
-import           System.Metrics.Prometheus.MetricId         (Labels, Name)
+import           System.Metrics.Prometheus.MetricId         (Labels, MetricId,
+                                                             Name)
 import           System.Metrics.Prometheus.Registry         (Registry,
                                                              RegistrySample,
                                                              new)
@@ -51,6 +52,14 @@ registerGauge n l = withRegistry (liftIO . R.registerGauge n l)
 
 registerHistogram :: MonadIO m => Name -> Labels -> [Histogram.UpperBound] -> RegistryT m Histogram
 registerHistogram n l u = withRegistry (liftIO . R.registerHistogram n l u)
+
+
+removeMetric :: MonadIO m => MetricId -> RegistryT m ()
+removeMetric i = withRegistry (pure . (,) () . R.removeMetric i)
+
+
+listMetricIds :: MonadIO m => RegistryT m [MetricId]
+listMetricIds = R.listMetricIds <$> RegistryT get
 
 
 sample :: Monad m => RegistryT m (IO RegistrySample)


### PR DESCRIPTION
Added functionality to list all `MetricId` in a registry and to remove metrics from a registry.

Usecase is that I have metrics which are only valid for a certain time and then should be removed from the output again.