### PR TITLE
Add set for Counter

### DIFF
--- a/src/System/Metrics/Prometheus/Metric/Counter.hs
+++ b/src/System/Metrics/Prometheus/Metric/Counter.hs
@@ -6,11 +6,12 @@ module System.Metrics.Prometheus.Metric.Counter
        , inc
        , sample
        , addAndSample
+       , set
        ) where
 
 
 import           Control.Applicative  ((<$>))
-import           Data.Atomics.Counter (AtomicCounter, incrCounter, newCounter)
+import           Data.Atomics.Counter (AtomicCounter, incrCounter, newCounter, writeCounter)
 
 
 newtype Counter = Counter { unCounter :: AtomicCounter }
@@ -36,3 +37,6 @@ inc = add 1
 
 sample :: Counter -> IO CounterSample
 sample = addAndSample 0
+
+set :: Int -> Counter -> IO ()
+set i (Counter c) = writeCounter c i


### PR DESCRIPTION
This is for the case where a separate service (i.e. GHC's RTS) maintains a count on your behalf, therefore inc/dec don't apply and would be more work to figure out than simply setting the counter. Example: how much time has been spent in GC. This number always increases (a counter), but if I simply `add`, that is incorrect. A `set` is the right action.