### PR TITLE
Fix bug with observeAndSample function from Histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+
+## 2.3.0
+
+*   Change the `observeAndSample` function from the
+    `System.Metrics.Prometheus.Metric.Histogram` module to return the value of
+    the sample that was just added, instead of the previous sample.
+    This change matches similar functions for `Counter`s and `Gauge`s.
+    [#51](https://github.com/bitnomial/prometheus/pull/51)

--- a/prometheus.cabal
+++ b/prometheus.cabal
@@ -1,5 +1,5 @@
 name:                prometheus
-version:             2.2.4
+version:             2.3.0
 synopsis:            Prometheus Haskell Client
 homepage:            http://github.com/bitnomial/prometheus
 bug-reports:         http://github.com/bitnomial/prometheus/issues
@@ -7,7 +7,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Luke Hoersten
 maintainer:          luke@bitnomial.com, opensource@bitnomial.com
-copyright:           Bitnomial, Inc. (c) 2016-2019
+copyright:           Bitnomial, Inc. (c) 2016-2023
 category:            Metrics, Monitoring, Web, System
 build-type:          Simple
 cabal-version:       >=1.10

--- a/src/System/Metrics/Prometheus/Metric/Counter.hs
+++ b/src/System/Metrics/Prometheus/Metric/Counter.hs
@@ -15,7 +15,7 @@ import Data.Atomics.Counter (AtomicCounter, incrCounter, newCounter, writeCounte
 
 
 newtype Counter = Counter {unCounter :: AtomicCounter}
-newtype CounterSample = CounterSample {unCounterSample :: Int}
+newtype CounterSample = CounterSample {unCounterSample :: Int} deriving Show
 
 
 new :: IO Counter

--- a/src/System/Metrics/Prometheus/Metric/Gauge.hs
+++ b/src/System/Metrics/Prometheus/Metric/Gauge.hs
@@ -16,7 +16,7 @@ import Data.IORef (IORef, atomicModifyIORef', newIORef)
 
 
 newtype Gauge = Gauge {unGauge :: IORef Double}
-newtype GaugeSample = GaugeSample {unGaugeSample :: Double}
+newtype GaugeSample = GaugeSample {unGaugeSample :: Double} deriving Show
 
 
 new :: IO Gauge

--- a/src/System/Metrics/Prometheus/Metric/Histogram.hs
+++ b/src/System/Metrics/Prometheus/Metric/Histogram.hs
@@ -36,6 +36,7 @@ data HistogramSample = HistogramSample
     , histSum :: !Double
     , histCount :: !Int
     }
+    deriving Show
 
 
 new :: [UpperBound] -> IO Histogram

--- a/src/System/Metrics/Prometheus/Metric/Histogram.hs
+++ b/src/System/Metrics/Prometheus/Metric/Histogram.hs
@@ -50,7 +50,7 @@ new buckets = Histogram <$> newIORef empty
 observeAndSample :: Double -> Histogram -> IO HistogramSample
 observeAndSample x = flip atomicModifyIORef' update . unHistogram
   where
-    update histData = (hist' histData, histData)
+    update histData = (hist' histData, hist' histData)
     hist' histData =
         histData
             { histBuckets = updateBuckets x $ histBuckets histData

--- a/src/System/Metrics/Prometheus/Metric/Summary.hs
+++ b/src/System/Metrics/Prometheus/Metric/Summary.hs
@@ -8,3 +8,4 @@ data SummarySample = SummarySample
     , sumSum :: !Int
     , sumCount :: !Int
     }
+    deriving Show


### PR DESCRIPTION
The Histogram metric has a function `observeAndSample`, which lets you add a new observation, and sample it at the same time.  Before this commit, this `observeAndSample` function would return the _previous_ sample, _not_ the sample you just added.

This commit changes the behavior of `observeAndSample` so that it returns the sample that was just added.  This matches the behavior of `addAndSample` (from `Counter`), and `modifyAndSample` (from `Gauge`), which both return the value of the sample that was just added.

Here's an example program that demonstrates this problem:

```haskell
{-# LANGUAGE OverloadedStrings #-}

module Main where

import Control.Monad.IO.Class (liftIO)
import System.Metrics.Prometheus.Concurrent.RegistryT
import System.Metrics.Prometheus.Metric.Counter (addAndSample)
import System.Metrics.Prometheus.Metric.Histogram (observeAndSample)
import System.Metrics.Prometheus.MetricId


main :: IO ()
main = runRegistryT $ do
    exampleCounter <- registerCounter "example_counter" mempty
    exampleHist <- registerHistogram "example_hist" mempty [10, 20 .. 100]

    liftIO $ do
      counterResult <- addAndSample 29 exampleCounter
      histResult <- observeAndSample 59 exampleHist
      print counterResult
      print histResult
```

Running this on `master` gives output like the following:

```
CounterSample {unCounterSample = 29}
HistogramSample {histBuckets = fromList [(10.0,0.0),(20.0,0.0),(30.0,0.0),(40.0,0.0),(50.0,0.0),(60.0,0.0),(70.0,0.0),(80.0,0.0),(90.0,0.0),(100.0,0.0),(Infinity,0.0)], histSum = 0.0, histCount = 0}
```

You can see that while the result of `addAndSample` for the `Counter` returns 29 (which was the value just added), the result of `observeAndSample` for the `Histogram` returns all zeros (which is the initial state of a histogram).

Running this same program in this PR results in:

```
CounterSample {unCounterSample = 29}
HistogramSample {histBuckets = fromList [(10.0,0.0),(20.0,0.0),(30.0,0.0),(40.0,0.0),(50.0,0.0),(60.0,1.0),(70.0,1.0),(80.0,1.0),(90.0,1.0),(100.0,1.0),(Infinity,1.0)], histSum = 59.0, histCount = 1}
```

Now you can see that the resulting `Histogram` sample correctly has a single observation.